### PR TITLE
feat: add login attempt blocking

### DIFF
--- a/backend/src/database/migrate.js
+++ b/backend/src/database/migrate.js
@@ -20,6 +20,21 @@ async function migrate() {
       ON users (LOWER(email));
     `);
 
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS login_attempts (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        email VARCHAR(160) NOT NULL,
+        failed_attempts INTEGER NOT NULL DEFAULT 0,
+        blocked_until TIMESTAMP NULL,
+        last_attempt_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+
+    await pool.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS login_attempts_email_unique_idx
+      ON login_attempts (LOWER(email));
+    `);
+
     console.log("Migrations executed successfully.");
   } catch (error) {
     console.error("Migration failed:", error);

--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -7,6 +7,79 @@ const { isValidEmail, isValidPassword } = require("../utils/validators");
 
 const router = express.Router();
 
+const MAX_LOGIN_ATTEMPTS = 5;
+const BLOCK_TIME_IN_MINUTES = 15;
+
+async function getLoginAttempt(email) {
+  const result = await pool.query(
+    `
+      SELECT id, email, failed_attempts, blocked_until
+      FROM login_attempts
+      WHERE LOWER(email) = LOWER($1)
+    `,
+    [email]
+  );
+
+  return result.rows[0];
+}
+
+async function isEmailBlocked(email) {
+  const loginAttempt = await getLoginAttempt(email);
+
+  if (!loginAttempt || !loginAttempt.blocked_until) {
+    return false;
+  }
+
+  const blockedUntil = new Date(loginAttempt.blocked_until);
+  const now = new Date();
+
+  return blockedUntil > now;
+}
+
+async function registerFailedLoginAttempt(email) {
+  const loginAttempt = await getLoginAttempt(email);
+
+  if (!loginAttempt) {
+    await pool.query(
+      `
+        INSERT INTO login_attempts (email, failed_attempts, last_attempt_at)
+        VALUES ($1, 1, CURRENT_TIMESTAMP)
+      `,
+      [email]
+    );
+
+    return;
+  }
+
+  const nextFailedAttempts = loginAttempt.failed_attempts + 1;
+  const shouldBlock = nextFailedAttempts >= MAX_LOGIN_ATTEMPTS;
+
+  await pool.query(
+    `
+      UPDATE login_attempts
+      SET
+        failed_attempts = $1,
+        blocked_until = CASE
+          WHEN $2 = true THEN CURRENT_TIMESTAMP + INTERVAL '${BLOCK_TIME_IN_MINUTES} minutes'
+          ELSE blocked_until
+        END,
+        last_attempt_at = CURRENT_TIMESTAMP
+      WHERE LOWER(email) = LOWER($3)
+    `,
+    [nextFailedAttempts, shouldBlock, email]
+  );
+}
+
+async function clearLoginAttempts(email) {
+  await pool.query(
+    `
+      DELETE FROM login_attempts
+      WHERE LOWER(email) = LOWER($1)
+    `,
+    [email]
+  );
+}
+
 router.post("/register", async (req, res) => {
   try {
     const { name, email, password, acceptedTerms } = req.body;
@@ -81,16 +154,29 @@ router.post("/login", async (req, res) => {
       });
     }
 
+    const normalizedEmail = email.trim().toLowerCase();
+
+    const blocked = await isEmailBlocked(normalizedEmail);
+
+    if (blocked) {
+      return res.status(429).json({
+        message:
+          "Acesso temporariamente bloqueado por excesso de tentativas. Tente novamente mais tarde.",
+      });
+    }
+
     const userResult = await pool.query(
       `
         SELECT id, name, email, password_hash
         FROM users
         WHERE LOWER(email) = LOWER($1)
       `,
-      [email]
+      [normalizedEmail]
     );
 
     if (userResult.rows.length === 0) {
+      await registerFailedLoginAttempt(normalizedEmail);
+
       return res.status(401).json({
         message: "Email inválido.",
       });
@@ -101,10 +187,14 @@ router.post("/login", async (req, res) => {
     const passwordMatches = await bcrypt.compare(password, user.password_hash);
 
     if (!passwordMatches) {
+      await registerFailedLoginAttempt(normalizedEmail);
+
       return res.status(401).json({
         message: "Email ou senha incorretos.",
       });
     }
+
+    await clearLoginAttempts(normalizedEmail);
 
     const token = jwt.sign(
       {


### PR DESCRIPTION
## O que foi feito

- Criada tabela `login_attempts` para controlar tentativas de login malsucedidas.
- Adicionado controle de tentativas por email.
- Implementado bloqueio temporário após 5 tentativas consecutivas de login malsucedidas.
- Configurado tempo de bloqueio de 15 minutos.
- Implementada limpeza das tentativas após login realizado com sucesso.
- Mantidas as mensagens de erro previstas no card para email inexistente e senha incorreta.

## Como testar

1. Subir o banco:

```bash
docker compose up -d
```

2. Rodar o migration

```bash
cd backend
npm run migrate
```
3. Rodar o backend

```bash
npm run dev
```
4. Testar login com senha incorreta 5 vezes:

```bash
curl -X POST http://localhost:3333/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{
    "email": "bloqueio@email.com",
    "password": "Errada"
  }'
```

## Resultado esperado
- Antes do bloqueio, o sistema retorna Email ou senha incorretos.
- Após 5 tentativas consecutivas malsucedidas, o sistema retorna mensagem de bloqueio temporário.
- Após login correto, as tentativas anteriores são limpas.

## Observações

Este PR implementa a regra de negócio de bloqueio temporário após múltiplas tentativas de login malsucedidas.