### PR TITLE
feat: add password recovery request flow

### DIFF
--- a/backend/src/database/migrate.js
+++ b/backend/src/database/migrate.js
@@ -35,6 +35,22 @@ async function migrate() {
       ON login_attempts (LOWER(email));
     `);
 
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS password_reset_tokens (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        token TEXT NOT NULL,
+        expires_at TIMESTAMP NOT NULL,
+        used_at TIMESTAMP NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+
+    await pool.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS password_reset_tokens_token_unique_idx
+      ON password_reset_tokens (token);
+    `);
+
     console.log("Migrations executed successfully.");
   } catch (error) {
     console.error("Migration failed:", error);

--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -1,3 +1,4 @@
+const crypto = require("crypto");
 const express = require("express");
 const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
@@ -221,6 +222,70 @@ router.post("/login", async (req, res) => {
 
     return res.status(500).json({
       message: "Erro interno ao realizar login.",
+    });
+  }
+});
+
+router.post("/forgot-password", async (req, res) => {
+  try {
+    const { email } = req.body;
+
+    if (!email) {
+      return res.status(400).json({
+        message: "Informe seu email.",
+      });
+    }
+
+    if (!isValidEmail(email)) {
+      return res.status(400).json({
+        message: "Email inválido.",
+      });
+    }
+
+    const normalizedEmail = email.trim().toLowerCase();
+
+    const userResult = await pool.query(
+      `
+        SELECT id, name, email
+        FROM users
+        WHERE LOWER(email) = LOWER($1)
+      `,
+      [normalizedEmail]
+    );
+
+    if (userResult.rows.length === 0) {
+      return res.status(200).json({
+        message:
+          "Se o email informado estiver cadastrado, enviaremos um link para redefinição de senha.",
+      });
+    }
+
+    const user = userResult.rows[0];
+    const resetToken = crypto.randomBytes(32).toString("hex");
+
+    await pool.query(
+      `
+        INSERT INTO password_reset_tokens (user_id, token, expires_at)
+        VALUES ($1, $2, CURRENT_TIMESTAMP + INTERVAL '1 hour')
+      `,
+      [user.id, resetToken]
+    );
+
+    const resetLink = `http://localhost:5173/redefinir-senha?token=${resetToken}`;
+
+    console.log("Password reset requested:");
+    console.log(`User: ${user.name} <${user.email}>`);
+    console.log(`Reset link: ${resetLink}`);
+
+    return res.status(200).json({
+      message:
+        "Se o email informado estiver cadastrado, enviaremos um link para redefinição de senha.",
+    });
+  } catch (error) {
+    console.error("Forgot password error:", error);
+
+    return res.status(500).json({
+      message: "Erro interno ao solicitar recuperação de senha.",
     });
   }
 });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,17 +2,19 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import Register from "./pages/Register";
 import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
+import ForgotPassword from "./pages/ForgotPassword";
 
-function RecoveryPlaceholder() {
+function ResetPasswordPlaceholder() {
   return (
     <main className="login-page">
       <section className="login-card">
         <div className="brand-logo">✓</div>
 
-        <h1>Recuperar senha</h1>
+        <h1>Redefinir senha</h1>
 
         <p>
-          A recuperação de senha será implementada no próximo PR deste card.
+          A tela para criar uma nova senha será implementada no próximo PR deste
+          card.
         </p>
 
         <a href="/login">Voltar para login</a>
@@ -29,7 +31,8 @@ export default function App() {
         <Route path="/cadastro" element={<Register />} />
         <Route path="/login" element={<Login />} />
         <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="/recuperar-senha" element={<RecoveryPlaceholder />} />
+        <Route path="/recuperar-senha" element={<ForgotPassword />} />
+        <Route path="/redefinir-senha" element={<ResetPasswordPlaceholder />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/ForgotPassword.jsx
+++ b/frontend/src/pages/ForgotPassword.jsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+import { api } from "../services/api";
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  function handleChange(event) {
+    setEmail(event.target.value);
+    setError("");
+    setSuccess("");
+  }
+
+  function validateForm() {
+    if (!email.trim()) {
+      return "Informe seu email.";
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+    if (!emailRegex.test(email)) {
+      return "Email inválido.";
+    }
+
+    return "";
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    setError("");
+    setSuccess("");
+
+    const validationError = validateForm();
+
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+
+      const response = await api.post("/auth/forgot-password", {
+        email: email.trim(),
+      });
+
+      setSuccess(response.data.message);
+    } catch (error) {
+      const message =
+        error.response?.data?.message ||
+        "Não foi possível solicitar a recuperação de senha.";
+
+      setError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="auth-page">
+      <section className="auth-card login-auth-card">
+        <div className="brand">
+          <div className="brand-logo">✓</div>
+
+          <div>
+            <strong>TaskFlow</strong>
+            <span>Gestão inteligente de tarefas</span>
+          </div>
+        </div>
+
+        <div className="form-heading">
+          <span className="eyebrow">Recuperação de acesso</span>
+
+          <h1>Esqueceu sua senha?</h1>
+
+          <p>
+            Informe o email cadastrado na sua conta para receber um link de
+            redefinição de senha.
+          </p>
+        </div>
+
+        <form className="register-form" onSubmit={handleSubmit} noValidate>
+          <label>
+            Email
+            <input
+              type="text"
+              inputMode="email"
+              name="email"
+              placeholder="seuemail@exemplo.com"
+              value={email}
+              onChange={handleChange}
+            />
+          </label>
+
+          {error && <div className="form-message error">{error}</div>}
+          {success && <div className="form-message success">{success}</div>}
+
+          <button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? "Enviando..." : "Enviar link de recuperação"}
+          </button>
+        </form>
+
+        <p className="login-link">
+          Lembrou sua senha? <a href="/login">Voltar para login</a>
+        </p>
+      </section>
+
+      <section className="showcase-panel login-showcase-panel">
+        <div className="showcase-content">
+          <span className="showcase-badge">Acesso seguro</span>
+
+          <h2>Recupere sua conta com praticidade.</h2>
+
+          <p>
+            Enviaremos as instruções para redefinir sua senha de forma segura e
+            continuar acompanhando suas tarefas.
+          </p>
+
+          <div className="task-preview">
+            <div className="task-preview-header">
+              <span>Etapas de recuperação</span>
+              <strong>3 passos</strong>
+            </div>
+
+            <div className="task-item high">
+              <span></span>
+
+              <div>
+                <strong>Informe seu email</strong>
+                <small>Use o email cadastrado</small>
+              </div>
+            </div>
+
+            <div className="task-item medium">
+              <span></span>
+
+              <div>
+                <strong>Acesse o link recebido</strong>
+                <small>O link expira por segurança</small>
+              </div>
+            </div>
+
+            <div className="task-item low">
+              <span></span>
+
+              <div>
+                <strong>Crie uma nova senha</strong>
+                <small>Depois é só entrar novamente</small>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## O que foi feito

- Criada tabela `login_attempts` para controlar tentativas de login malsucedidas.
- Adicionado controle de tentativas por email.
- Implementado bloqueio temporário após 5 tentativas consecutivas de login malsucedidas.
- Configurado tempo de bloqueio de 15 minutos.
- Implementada limpeza das tentativas após login realizado com sucesso.
- Mantidas as mensagens de erro previstas no card para email inexistente e senha incorreta.

## Como testar

1. Subir o banco:

```bash
docker compose up -d
```

2. Rodar o migration

```bash
cd backend
npm run migrate
```
3. Rodar o backend

```bash
npm run dev
```
4. Rodar o frontend

```bash
cd frontend
npm install
npm run dev
```

5. Acessar

```text
http://localhost:5173/recuperar-senha
```

## Cenários Validados

- Email válido cadastrado
- Email válido não cadastrado
- Email em formato inválido

## Observações

Este PR implementa a solicitação de recuperação de senha. O envio real de email foi simulado no console do backend para fins de desenvolvimento local. A tela de redefinição de senha será implementada no próximo PR.
