### PR TITLE
feat: create password reset page

### DIFF
--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -290,4 +290,101 @@ router.post("/forgot-password", async (req, res) => {
   }
 });
 
+router.post("/reset-password", async (req, res) => {
+  try {
+    const { token, password } = req.body;
+
+    if (!token || !password) {
+      return res.status(400).json({
+        message: "Informe o token e a nova senha.",
+      });
+    }
+
+    if (!isValidPassword(password)) {
+      return res.status(400).json({
+        message:
+          "A senha deve ter no mínimo 4 caracteres e pelo menos uma letra maiúscula.",
+      });
+    }
+
+    const tokenResult = await pool.query(
+      `
+        SELECT
+          password_reset_tokens.id,
+          password_reset_tokens.user_id,
+          password_reset_tokens.expires_at,
+          password_reset_tokens.used_at
+        FROM password_reset_tokens
+        WHERE password_reset_tokens.token = $1
+      `,
+      [token]
+    );
+
+    if (tokenResult.rows.length === 0) {
+      return res.status(400).json({
+        message: "Link de redefinição inválido.",
+      });
+    }
+
+    const resetToken = tokenResult.rows[0];
+
+    if (resetToken.used_at) {
+      return res.status(400).json({
+        message: "Este link de redefinição já foi utilizado.",
+      });
+    }
+
+    const now = new Date();
+    const expiresAt = new Date(resetToken.expires_at);
+
+    if (expiresAt < now) {
+      return res.status(400).json({
+        message: "Este link de redefinição expirou.",
+      });
+    }
+
+    const passwordHash = await bcrypt.hash(password, 10);
+
+    await pool.query(
+      `
+        UPDATE users
+        SET password_hash = $1
+        WHERE id = $2
+      `,
+      [passwordHash, resetToken.user_id]
+    );
+
+    await pool.query(
+      `
+        UPDATE password_reset_tokens
+        SET used_at = CURRENT_TIMESTAMP
+        WHERE id = $1
+      `,
+      [resetToken.id]
+    );
+
+    await pool.query(
+      `
+        DELETE FROM login_attempts
+        WHERE email = (
+          SELECT email
+          FROM users
+          WHERE id = $1
+        )
+      `,
+      [resetToken.user_id]
+    );
+
+    return res.status(200).json({
+      message: "Senha redefinida com sucesso.",
+    });
+  } catch (error) {
+    console.error("Reset password error:", error);
+
+    return res.status(500).json({
+      message: "Erro interno ao redefinir senha.",
+    });
+  }
+});
+
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,25 +3,7 @@ import Register from "./pages/Register";
 import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import ForgotPassword from "./pages/ForgotPassword";
-
-function ResetPasswordPlaceholder() {
-  return (
-    <main className="login-page">
-      <section className="login-card">
-        <div className="brand-logo">✓</div>
-
-        <h1>Redefinir senha</h1>
-
-        <p>
-          A tela para criar uma nova senha será implementada no próximo PR deste
-          card.
-        </p>
-
-        <a href="/login">Voltar para login</a>
-      </section>
-    </main>
-  );
-}
+import ResetPassword from "./pages/ResetPassword";
 
 export default function App() {
   return (
@@ -32,7 +14,7 @@ export default function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/recuperar-senha" element={<ForgotPassword />} />
-        <Route path="/redefinir-senha" element={<ResetPasswordPlaceholder />} />
+        <Route path="/redefinir-senha" element={<ResetPassword />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/ResetPassword.jsx
+++ b/frontend/src/pages/ResetPassword.jsx
@@ -1,0 +1,202 @@
+import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { api } from "../services/api";
+
+export default function ResetPassword() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  const token = searchParams.get("token");
+
+  const [formData, setFormData] = useState({
+    password: "",
+    confirmPassword: "",
+  });
+
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  function handleChange(event) {
+    const { name, value } = event.target;
+
+    setError("");
+    setSuccess("");
+
+    setFormData((currentData) => ({
+      ...currentData,
+      [name]: value,
+    }));
+  }
+
+  function validateForm() {
+    if (!token) {
+      return "Link de redefinição inválido.";
+    }
+
+    if (!formData.password) {
+      return "Informe a nova senha.";
+    }
+
+    if (!formData.confirmPassword) {
+      return "Confirme a nova senha.";
+    }
+
+    if (formData.password !== formData.confirmPassword) {
+      return "As senhas informadas não conferem.";
+    }
+
+    const hasMinimumLength = formData.password.length >= 4;
+    const hasUppercaseLetter = /[A-Z]/.test(formData.password);
+
+    if (!hasMinimumLength || !hasUppercaseLetter) {
+      return "A senha deve ter no mínimo 4 caracteres e pelo menos uma letra maiúscula.";
+    }
+
+    return "";
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    setError("");
+    setSuccess("");
+
+    const validationError = validateForm();
+
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+
+      const response = await api.post("/auth/reset-password", {
+        token,
+        password: formData.password,
+      });
+
+      setSuccess(response.data.message);
+
+      setTimeout(() => {
+        navigate("/login");
+      }, 1400);
+    } catch (error) {
+      const message =
+        error.response?.data?.message ||
+        "Não foi possível redefinir sua senha.";
+
+      setError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="auth-page">
+      <section className="auth-card login-auth-card">
+        <div className="brand">
+          <div className="brand-logo">✓</div>
+
+          <div>
+            <strong>TaskFlow</strong>
+            <span>Gestão inteligente de tarefas</span>
+          </div>
+        </div>
+
+        <div className="form-heading">
+          <span className="eyebrow">Nova senha</span>
+
+          <h1>Redefinir senha</h1>
+
+          <p>
+            Crie uma nova senha para recuperar o acesso à sua conta.
+          </p>
+        </div>
+
+        <form className="register-form" onSubmit={handleSubmit} noValidate>
+          <label>
+            Nova senha
+            <input
+              type="password"
+              name="password"
+              placeholder="Mínimo 4 caracteres e 1 letra maiúscula"
+              value={formData.password}
+              onChange={handleChange}
+            />
+          </label>
+
+          <label>
+            Confirmar nova senha
+            <input
+              type="password"
+              name="confirmPassword"
+              placeholder="Digite a nova senha novamente"
+              value={formData.confirmPassword}
+              onChange={handleChange}
+            />
+          </label>
+
+          {error && <div className="form-message error">{error}</div>}
+          {success && <div className="form-message success">{success}</div>}
+
+          <button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? "Redefinindo..." : "Redefinir senha"}
+          </button>
+        </form>
+
+        <p className="login-link">
+          Lembrou sua senha? <a href="/login">Voltar para login</a>
+        </p>
+      </section>
+
+      <section className="showcase-panel login-showcase-panel">
+        <div className="showcase-content">
+          <span className="showcase-badge">Conta protegida</span>
+
+          <h2>Escolha uma nova senha para continuar.</h2>
+
+          <p>
+            Após redefinir sua senha, você poderá entrar novamente e acessar seu
+            painel de tarefas com segurança.
+          </p>
+
+          <div className="task-preview">
+            <div className="task-preview-header">
+              <span>Recomendações</span>
+              <strong>Senha segura</strong>
+            </div>
+
+            <div className="task-item high">
+              <span></span>
+
+              <div>
+                <strong>Use letras maiúsculas</strong>
+                <small>Exigência mínima da plataforma</small>
+              </div>
+            </div>
+
+            <div className="task-item medium">
+              <span></span>
+
+              <div>
+                <strong>Evite senhas óbvias</strong>
+                <small>Não use dados fáceis de adivinhar</small>
+              </div>
+            </div>
+
+            <div className="task-item low">
+              <span></span>
+
+              <div>
+                <strong>Guarde sua senha</strong>
+                <small>Use uma senha que você consiga lembrar</small>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## O que foi feito

- Criado endpoint `POST /api/auth/reset-password`.
- Implementada validação do token de redefinição de senha.
- Implementada validação de token inexistente, expirado ou já utilizado.
- Implementada validação da nova senha.
- Implementada atualização da senha do usuário usando hash com `bcryptjs`.
- Implementada marcação do token como utilizado após a redefinição.
- Implementada limpeza de tentativas de login após redefinição de senha.
- Criada tela `/redefinir-senha`.
- Implementada leitura do token pela URL.
- Implementada validação de confirmação de senha no frontend.
- Implementado redirecionamento para `/login` após redefinição com sucesso.

## Como testar

1. Subir o banco:

```bash
docker compose up -d
```

2. Rodar o back end

```bash
cd backend
npm run migrate
npm run dev
```

3. Rodar frontend:

```bash
cd frontend
npm run dev
```

4. Solicitar recuperação em: 

```text
http://localhost:5173/recuperar-senha
```

5. Copiar o link gerado no console do backend.

6.  Acessar o link /redefinir-senha?token=....

7. Informar e confirmar a nova senha.

## Cenários Validados

- Redefinição com sucesso
- Token ausente ou inválido
- Token já utilizado
- Senha inválida
- Confirmação de senha diferente

## Observações

Este PR conclui o fluxo funcional de recuperação e redefinição de senha, utilizando token temporário salvo no banco.