### PR TITLE
feat: create authenticated app layout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,17 +4,22 @@ import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import ForgotPassword from "./pages/ForgotPassword";
 import ResetPassword from "./pages/ResetPassword";
+import AuthenticatedLayout from "./layouts/AuthenticatedLayout";
 
 export default function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Navigate to="/cadastro" />} />
+
         <Route path="/cadastro" element={<Register />} />
         <Route path="/login" element={<Login />} />
-        <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/recuperar-senha" element={<ForgotPassword />} />
         <Route path="/redefinir-senha" element={<ResetPassword />} />
+
+        <Route element={<AuthenticatedLayout />}>
+          <Route path="/dashboard" element={<Dashboard />} />
+        </Route>
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -611,3 +611,99 @@ a:hover {
     padding: 28px;
   }
 }
+
+.app-shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  background:
+    radial-gradient(circle at top left, rgba(80, 112, 255, 0.16), transparent 28%),
+    linear-gradient(135deg, #f8fbff 0%, #edf2fb 100%);
+}
+
+.app-sidebar-placeholder {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  padding: 24px;
+  border-right: 1px solid rgba(211, 220, 237, 0.9);
+  background: rgba(255, 255, 255, 0.86);
+  backdrop-filter: blur(18px);
+}
+
+.compact-brand {
+  margin-bottom: 0;
+}
+
+.app-content-area {
+  min-width: 0;
+  padding: 24px;
+}
+
+.app-navbar-placeholder {
+  min-height: 104px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 24px 28px;
+  border: 1px solid rgba(211, 220, 237, 0.9);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 18px 60px rgba(32, 48, 80, 0.1);
+}
+
+.app-navbar-placeholder h1 {
+  margin: 8px 0 0;
+  font-size: 28px;
+  letter-spacing: -0.05em;
+}
+
+.user-chip {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  color: #ffffff;
+  font-size: 20px;
+  font-weight: 900;
+  background: linear-gradient(135deg, #4763ff, #7a5cff);
+  box-shadow: 0 14px 28px rgba(71, 99, 255, 0.26);
+}
+
+.app-page-content {
+  margin-top: 24px;
+}
+
+.dashboard-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.dashboard-screen .dashboard-hero {
+  margin-top: 0;
+}
+
+@media (max-width: 900px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .app-sidebar-placeholder {
+    position: relative;
+    height: auto;
+    border-right: none;
+    border-bottom: 1px solid rgba(211, 220, 237, 0.9);
+  }
+
+  .app-content-area {
+    padding: 16px;
+  }
+
+  .app-navbar-placeholder {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/frontend/src/layouts/AuthenticatedLayout.jsx
+++ b/frontend/src/layouts/AuthenticatedLayout.jsx
@@ -1,0 +1,42 @@
+import { Navigate, Outlet } from "react-router-dom";
+
+export default function AuthenticatedLayout() {
+  const token = localStorage.getItem("taskflow:token");
+  const user = JSON.parse(localStorage.getItem("taskflow:user") || "null");
+
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return (
+    <main className="app-shell">
+      <aside className="app-sidebar-placeholder">
+        <div className="brand compact-brand">
+          <div className="brand-logo">✓</div>
+
+          <div>
+            <strong>TaskFlow</strong>
+            <span>Menu</span>
+          </div>
+        </div>
+      </aside>
+
+      <section className="app-content-area">
+        <header className="app-navbar-placeholder">
+          <div>
+            <span className="eyebrow">Área autenticada</span>
+            <h1>Olá, {user?.name || "usuário"}.</h1>
+          </div>
+
+          <div className="user-chip">
+            {user?.name?.charAt(0)?.toUpperCase() || "U"}
+          </div>
+        </header>
+
+        <section className="app-page-content">
+          <Outlet />
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,44 +1,15 @@
-import { useNavigate } from "react-router-dom";
-
 export default function Dashboard() {
-  const navigate = useNavigate();
-
-  const user = JSON.parse(localStorage.getItem("taskflow:user") || "null");
-
-  function handleLogout() {
-    localStorage.removeItem("taskflow:token");
-    localStorage.removeItem("taskflow:user");
-
-    navigate("/login");
-  }
-
   return (
-    <main className="dashboard-page">
-      <header className="dashboard-header">
-        <div className="brand">
-          <div className="brand-logo">✓</div>
+    <section className="dashboard-screen">
+      <div className="dashboard-hero">
+        <span className="eyebrow">Dashboard</span>
 
-          <div>
-            <strong>TaskFlow</strong>
-            <span>Dashboard</span>
-          </div>
-        </div>
-
-        <button type="button" onClick={handleLogout}>
-          Sair
-        </button>
-      </header>
-
-      <section className="dashboard-hero">
-        <span className="eyebrow">Área do usuário</span>
-
-        <h1>Olá, {user?.name || "usuário"}.</h1>
+        <h1>Visão geral</h1>
 
         <p>
-          Login realizado com sucesso. Em breve, este painel exibirá seus
-          projetos, tarefas, prazos e notificações.
+          Acompanhe seus projetos, tarefas e notificações em um painel central.
         </p>
-      </section>
+      </div>
 
       <section className="dashboard-grid">
         <article>
@@ -56,6 +27,6 @@ export default function Dashboard() {
           <span>Alertas próximos</span>
         </article>
       </section>
-    </main>
+    </section>
   );
 }


### PR DESCRIPTION
## O que foi feito

- Criado layout base para telas autenticadas.
- Adicionado componente `AuthenticatedLayout`.
- Adicionada proteção simples por token salvo no `localStorage`.
- Ajustada rota `/dashboard` para utilizar o layout autenticado.
- Removido header próprio do dashboard para centralizar a navegação no layout.
- Criada estrutura visual inicial com área lateral, navbar superior e área de conteúdo.

## Como testar

1. Subir o banco:

```bash
docker compose up -d
```
2. Rodar o backend

```bash
cd backend
npm install
npm run migrate
npm run dev
```

3. Rodar o frontend

```bash
cd frontend
npm install
npm run dev
```

4. Acessar sem estar logado

http://localhost:5173/dashboard

5. Fazer login com usuário cadastrado.

Usuário deve ser redirecionado para /dashboard e visualizar o layout autenticado.

## Observações

Este PR cria a estrutura base do layout autenticado. A sidebar com navegação e a navbar com menu de perfil serão implementadas nos próximos PRs.