### PR TITLE
feat: add top navbar with profile menu

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,9 @@ import ResetPassword from "./pages/ResetPassword";
 import Projects from "./pages/Projects";
 import Tasks from "./pages/Tasks";
 import TodoList from "./pages/TodoList";
+import ProfileSettings from "./pages/ProfileSettings";
+import Notifications from "./pages/Notifications";
+import History from "./pages/History";
 import AuthenticatedLayout from "./layouts/AuthenticatedLayout";
 
 export default function App() {
@@ -25,6 +28,9 @@ export default function App() {
           <Route path="/projetos" element={<Projects />} />
           <Route path="/tasks" element={<Tasks />} />
           <Route path="/todo-list" element={<TodoList />} />
+          <Route path="/perfil" element={<ProfileSettings />} />
+          <Route path="/notificacoes" element={<Notifications />} />
+          <Route path="/historico" element={<History />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/components/TopNavbar.jsx
+++ b/frontend/src/components/TopNavbar.jsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+export default function TopNavbar() {
+  const navigate = useNavigate();
+  const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
+
+  const user = JSON.parse(localStorage.getItem("taskflow:user") || "null");
+
+  const userInitial = user?.name?.charAt(0)?.toUpperCase() || "U";
+  const userName = user?.name || "Usuário";
+  const userEmail = user?.email || "usuario@email.com";
+
+  function handleToggleProfileMenu() {
+    setIsProfileMenuOpen((currentValue) => !currentValue);
+  }
+
+  function handleLogout() {
+    localStorage.removeItem("taskflow:token");
+    localStorage.removeItem("taskflow:user");
+
+    navigate("/login");
+  }
+
+  return (
+    <header className="top-navbar">
+      <div className="top-navbar-content">
+        <div>
+          <span className="eyebrow">Área autenticada</span>
+          <h1>Olá, {userName}.</h1>
+        </div>
+
+        <div className="profile-menu-wrapper">
+          <button
+            type="button"
+            className="profile-menu-button"
+            onClick={handleToggleProfileMenu}
+            aria-expanded={isProfileMenuOpen}
+            aria-label="Abrir menu de perfil"
+          >
+            <div className="user-chip">{userInitial}</div>
+
+            <div className="profile-button-text">
+              <strong>{userName}</strong>
+              <span>{userEmail}</span>
+            </div>
+
+            <span className="profile-menu-arrow">
+              {isProfileMenuOpen ? "⌃" : "⌄"}
+            </span>
+          </button>
+
+          {isProfileMenuOpen && (
+            <div className="profile-dropdown">
+              <div className="profile-dropdown-header">
+                <div className="user-chip small">{userInitial}</div>
+
+                <div>
+                  <strong>{userName}</strong>
+                  <span>{userEmail}</span>
+                </div>
+              </div>
+
+              <nav className="profile-dropdown-nav">
+                <Link
+                  to="/perfil"
+                  onClick={() => setIsProfileMenuOpen(false)}
+                >
+                  Configurações do perfil
+                </Link>
+
+                <Link
+                  to="/notificacoes"
+                  onClick={() => setIsProfileMenuOpen(false)}
+                >
+                  Notificações
+                </Link>
+
+                <Link
+                  to="/historico"
+                  onClick={() => setIsProfileMenuOpen(false)}
+                >
+                  Histórico
+                </Link>
+
+                <button type="button" onClick={handleLogout}>
+                  Logout
+                </button>
+              </nav>
+            </div>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -630,25 +630,6 @@ a:hover {
   padding: 24px;
 }
 
-.app-navbar-placeholder {
-  min-height: 104px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-  padding: 24px 28px;
-  border: 1px solid rgba(211, 220, 237, 0.9);
-  border-radius: 28px;
-  background: rgba(255, 255, 255, 0.94);
-  box-shadow: 0 18px 60px rgba(32, 48, 80, 0.1);
-}
-
-.app-navbar-placeholder h1 {
-  margin: 8px 0 0;
-  font-size: 28px;
-  letter-spacing: -0.05em;
-}
-
 .user-chip {
   width: 48px;
   height: 48px;
@@ -683,11 +664,6 @@ a:hover {
 
   .app-content-area {
     padding: 16px;
-  }
-
-  .app-navbar-placeholder {
-    align-items: flex-start;
-    flex-direction: column;
   }
 }
 
@@ -864,5 +840,202 @@ a:hover {
 
   .module-hero {
     padding: 28px;
+  }
+}
+
+.top-navbar {
+  position: sticky;
+  top: 24px;
+  z-index: 20;
+}
+
+.top-navbar-content {
+  min-height: 104px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 24px 28px;
+  border: 1px solid rgba(211, 220, 237, 0.9);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 18px 60px rgba(32, 48, 80, 0.1);
+}
+
+.top-navbar-content h1 {
+  margin: 8px 0 0;
+  font-size: 28px;
+  letter-spacing: -0.05em;
+}
+
+.profile-menu-wrapper {
+  position: relative;
+}
+
+.profile-menu-button {
+  min-width: 260px;
+  border: 1px solid #d0d7e2;
+  border-radius: 20px;
+  padding: 10px 12px;
+  cursor: pointer;
+  background: #ffffff;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: #172033;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s,
+    transform 0.2s;
+}
+
+.profile-menu-button:hover {
+  border-color: #556cff;
+  box-shadow: 0 0 0 5px rgba(85, 108, 255, 0.1);
+  transform: translateY(-1px);
+}
+
+.profile-button-text {
+  min-width: 0;
+  flex: 1;
+  text-align: left;
+}
+
+.profile-button-text strong,
+.profile-button-text span {
+  display: block;
+}
+
+.profile-button-text strong {
+  color: #172033;
+  font-size: 14px;
+  font-weight: 900;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.profile-button-text span {
+  margin-top: 2px;
+  color: #667085;
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.profile-menu-arrow {
+  color: #667085;
+  font-size: 18px;
+  font-weight: 900;
+}
+
+.user-chip.small {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  font-size: 16px;
+}
+
+.profile-dropdown {
+  position: absolute;
+  top: calc(100% + 12px);
+  right: 0;
+  width: 292px;
+  padding: 12px;
+  border: 1px solid rgba(211, 220, 237, 0.95);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: 0 24px 70px rgba(32, 48, 80, 0.18);
+  z-index: 30;
+}
+
+.profile-dropdown-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 16px;
+  background: #f8fbff;
+}
+
+.profile-dropdown-header strong,
+.profile-dropdown-header span {
+  display: block;
+}
+
+.profile-dropdown-header strong {
+  color: #172033;
+  font-size: 14px;
+}
+
+.profile-dropdown-header span {
+  margin-top: 2px;
+  color: #667085;
+  font-size: 12px;
+}
+
+.profile-dropdown-nav {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.profile-dropdown-nav a,
+.profile-dropdown-nav button {
+  width: 100%;
+  border: none;
+  border-radius: 14px;
+  padding: 12px;
+  cursor: pointer;
+  background: transparent;
+  color: #475467;
+  font: inherit;
+  font-weight: 800;
+  text-align: left;
+  text-decoration: none;
+  transition:
+    background 0.2s,
+    color 0.2s;
+}
+
+.profile-dropdown-nav a:hover,
+.profile-dropdown-nav button:hover {
+  background: #eef2ff;
+  color: #4763ff;
+  text-decoration: none;
+}
+
+.profile-dropdown-nav button {
+  color: #b42318;
+}
+
+.profile-dropdown-nav button:hover {
+  background: #fff1f0;
+  color: #b42318;
+}
+
+@media (max-width: 720px) {
+  .top-navbar {
+    position: relative;
+    top: 0;
+  }
+
+  .top-navbar-content {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .profile-menu-wrapper,
+  .profile-menu-button {
+    width: 100%;
+  }
+
+  .profile-dropdown {
+    position: static;
+    width: 100%;
+    margin-top: 12px;
   }
 }

--- a/frontend/src/layouts/AuthenticatedLayout.jsx
+++ b/frontend/src/layouts/AuthenticatedLayout.jsx
@@ -1,9 +1,9 @@
 import { Navigate, Outlet } from "react-router-dom";
 import Sidebar from "../components/Sidebar";
+import TopNavbar from "../components/TopNavbar";
 
 export default function AuthenticatedLayout() {
   const token = localStorage.getItem("taskflow:token");
-  const user = JSON.parse(localStorage.getItem("taskflow:user") || "null");
 
   if (!token) {
     return <Navigate to="/login" replace />;
@@ -14,16 +14,7 @@ export default function AuthenticatedLayout() {
       <Sidebar />
 
       <section className="app-content-area">
-        <header className="app-navbar-placeholder">
-          <div>
-            <span className="eyebrow">Área autenticada</span>
-            <h1>Olá, {user?.name || "usuário"}.</h1>
-          </div>
-
-          <div className="user-chip">
-            {user?.name?.charAt(0)?.toUpperCase() || "U"}
-          </div>
-        </header>
+        <TopNavbar />
 
         <section className="app-page-content">
           <Outlet />

--- a/frontend/src/pages/History.jsx
+++ b/frontend/src/pages/History.jsx
@@ -1,0 +1,33 @@
+export default function History() {
+  return (
+    <section className="module-screen">
+      <div className="module-hero">
+        <span className="eyebrow">Histórico</span>
+
+        <h1>Histórico</h1>
+
+        <p>
+          Consulte registros de alterações, acessos e movimentações realizadas
+          no sistema.
+        </p>
+      </div>
+
+      <section className="module-grid">
+        <article>
+          <strong>0</strong>
+          <span>Alterações registradas</span>
+        </article>
+
+        <article>
+          <strong>0</strong>
+          <span>Acessos recentes</span>
+        </article>
+
+        <article>
+          <strong>0</strong>
+          <span>Eventos do sistema</span>
+        </article>
+      </section>
+    </section>
+  );
+}

--- a/frontend/src/pages/Notifications.jsx
+++ b/frontend/src/pages/Notifications.jsx
@@ -1,0 +1,33 @@
+export default function Notifications() {
+  return (
+    <section className="module-screen">
+      <div className="module-hero">
+        <span className="eyebrow">Notificações</span>
+
+        <h1>Notificações</h1>
+
+        <p>
+          Acompanhe alertas importantes sobre prazos, tarefas e movimentações da
+          sua conta.
+        </p>
+      </div>
+
+      <section className="module-grid">
+        <article>
+          <strong>0</strong>
+          <span>Não lidas</span>
+        </article>
+
+        <article>
+          <strong>0</strong>
+          <span>Alertas de prazo</span>
+        </article>
+
+        <article>
+          <strong>0</strong>
+          <span>Atualizações</span>
+        </article>
+      </section>
+    </section>
+  );
+}

--- a/frontend/src/pages/ProfileSettings.jsx
+++ b/frontend/src/pages/ProfileSettings.jsx
@@ -1,0 +1,33 @@
+export default function ProfileSettings() {
+  return (
+    <section className="module-screen">
+      <div className="module-hero">
+        <span className="eyebrow">Perfil</span>
+
+        <h1>Configurações do perfil</h1>
+
+        <p>
+          Gerencie suas informações pessoais, preferências de conta e dados de
+          acesso.
+        </p>
+      </div>
+
+      <section className="module-grid">
+        <article>
+          <strong>Dados</strong>
+          <span>Informações pessoais</span>
+        </article>
+
+        <article>
+          <strong>Conta</strong>
+          <span>Preferências de acesso</span>
+        </article>
+
+        <article>
+          <strong>Segurança</strong>
+          <span>Proteção da conta</span>
+        </article>
+      </section>
+    </section>
+  );
+}


### PR DESCRIPTION
## O que foi feito

- Criado componente `TopNavbar`.
- Substituída a navbar provisória do layout autenticado pela navbar real.
- Adicionado menu expansível de perfil.
- Adicionadas opções no menu:
  - Configurações do perfil
  - Notificações
  - Histórico
  - Logout
- Implementado logout limpando token e usuário do `localStorage`.
- Criadas páginas provisórias para `/perfil`, `/notificacoes` e `/historico`.
- Adicionadas rotas autenticadas para as páginas do menu de perfil.
- Adicionados estilos da navbar, botão de perfil e dropdown.

## Como testar

1. Subir o banco:

```bash
docker compose up -d
```bash

2. Rodar o backend

```bash
cd backend
npm install
npm run migrate
npm run dev
```

3. Rodar o frontend

```bash
cd frontend
npm install
npm run dev
```
4. Fazer login com usuário cadastrado.

5. Clicar no menu de perfil na navbar.

## Observações

Este PR implementa a navbar superior com menu de perfil. A documentação e ajustes finais do card serão feitos no próximo PR.