### PR TITLE
feat: create projects listing page

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1039,3 +1039,290 @@ a:hover {
     margin-top: 12px;
   }
 }
+
+.projects-hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.primary-action-button {
+  border: none;
+  border-radius: 18px;
+  padding: 14px 20px;
+  cursor: pointer;
+  color: #ffffff;
+  font-weight: 900;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.14), transparent),
+    linear-gradient(135deg, #4763ff, #7a5cff);
+  box-shadow: 0 18px 38px rgba(71, 99, 255, 0.28);
+  transition:
+    transform 0.2s,
+    box-shadow 0.2s,
+    opacity 0.2s;
+}
+
+.primary-action-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 48px rgba(71, 99, 255, 0.36);
+}
+
+.feedback-card,
+.empty-projects-card {
+  padding: 34px;
+  border: 1px solid rgba(211, 220, 237, 0.9);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 24px 80px rgba(32, 48, 80, 0.1);
+}
+
+.feedback-card strong,
+.feedback-card span {
+  display: block;
+}
+
+.feedback-card strong {
+  font-size: 20px;
+}
+
+.feedback-card span {
+  margin-top: 8px;
+  color: #667085;
+}
+
+.feedback-card.error {
+  border-color: #fecdca;
+  background: #fff1f0;
+  color: #b42318;
+}
+
+.feedback-card.error span {
+  color: #b42318;
+}
+
+.empty-projects-card {
+  text-align: center;
+}
+
+.empty-projects-icon {
+  width: 72px;
+  height: 72px;
+  margin: 0 auto 18px;
+  border-radius: 24px;
+  display: grid;
+  place-items: center;
+  color: #4763ff;
+  font-size: 34px;
+  font-weight: 900;
+  background: #eef2ff;
+}
+
+.empty-projects-card h2 {
+  margin: 0;
+  font-size: 30px;
+  letter-spacing: -0.04em;
+}
+
+.empty-projects-card p {
+  max-width: 560px;
+  margin: 12px auto 24px;
+  color: #667085;
+  line-height: 1.6;
+}
+
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.project-card {
+  min-height: 300px;
+  padding: 24px;
+  border: 1px solid rgba(211, 220, 237, 0.9);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 24px 80px rgba(32, 48, 80, 0.1);
+  display: flex;
+  flex-direction: column;
+  transition:
+    transform 0.2s,
+    box-shadow 0.2s,
+    border-color 0.2s;
+}
+
+.project-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(85, 108, 255, 0.32);
+  box-shadow: 0 30px 90px rgba(32, 48, 80, 0.14);
+}
+
+.project-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.project-label {
+  display: inline-flex;
+  margin-bottom: 8px;
+  color: #4763ff;
+  font-size: 13px;
+  font-weight: 900;
+}
+
+.project-card h2 {
+  margin: 0;
+  font-size: 25px;
+  letter-spacing: -0.04em;
+  line-height: 1.1;
+}
+
+.project-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.project-actions button {
+  width: 36px;
+  height: 36px;
+  border: 1px solid #d0d7e2;
+  border-radius: 12px;
+  cursor: pointer;
+  color: #475467;
+  background: #ffffff;
+  font-size: 18px;
+  font-weight: 900;
+  transition:
+    background 0.2s,
+    color 0.2s,
+    border-color 0.2s;
+}
+
+.project-actions button:hover {
+  border-color: #556cff;
+  color: #4763ff;
+  background: #eef2ff;
+}
+
+.project-description {
+  margin: 16px 0 0;
+  color: #667085;
+  line-height: 1.6;
+}
+
+.project-description.muted {
+  color: #98a2b3;
+}
+
+.project-progress-area {
+  margin-top: auto;
+  padding-top: 24px;
+}
+
+.project-progress-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.project-progress-header span {
+  color: #667085;
+  font-weight: 800;
+}
+
+.project-progress-header strong {
+  color: #172033;
+  font-size: 18px;
+}
+
+.project-progress-track {
+  height: 12px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: #eef2ff;
+}
+
+.project-progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #4763ff, #7a5cff);
+  transition: width 0.3s;
+}
+
+.project-progress-area small {
+  display: block;
+  margin-top: 9px;
+  color: #667085;
+  font-weight: 700;
+}
+
+.project-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px solid #edf1f7;
+}
+
+.project-members {
+  display: flex;
+  align-items: center;
+}
+
+.member-avatar {
+  width: 34px;
+  height: 34px;
+  margin-left: -8px;
+  border: 2px solid #ffffff;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 900;
+  background: linear-gradient(135deg, #4763ff, #7a5cff);
+  box-shadow: 0 8px 18px rgba(32, 48, 80, 0.14);
+}
+
+.member-avatar:first-child {
+  margin-left: 0;
+}
+
+.member-avatar.extra {
+  color: #475467;
+  background: #eef2ff;
+}
+
+.project-members-count {
+  color: #667085;
+  font-size: 14px;
+  font-weight: 800;
+}
+
+@media (max-width: 1180px) {
+  .projects-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .projects-hero {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .primary-action-button {
+    width: 100%;
+  }
+
+  .projects-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/Projects.jsx
+++ b/frontend/src/pages/Projects.jsx
@@ -1,33 +1,169 @@
+import { useEffect, useState } from "react";
+import { api } from "../services/api";
+
 export default function Projects() {
+  const [projects, setProjects] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  async function loadProjects() {
+    try {
+      setIsLoading(true);
+      setError("");
+
+      const response = await api.get("/projects");
+
+      setProjects(response.data.projects);
+    } catch (error) {
+      const message =
+        error.response?.data?.message || "Não foi possível carregar os projetos.";
+
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadProjects();
+  }, []);
+
+  function getMemberInitial(memberName) {
+    return memberName?.charAt(0)?.toUpperCase() || "U";
+  }
+
   return (
     <section className="module-screen">
-      <div className="module-hero">
-        <span className="eyebrow">Projetos</span>
+      <div className="module-hero projects-hero">
+        <div>
+          <span className="eyebrow">Projetos</span>
 
-        <h1>Projetos</h1>
+          <h1>Projetos</h1>
 
-        <p>
-          Organize suas iniciativas por projeto e acompanhe o andamento das
-          atividades em um só lugar.
-        </p>
+          <p>
+            Organize tarefas relacionadas em projetos e acompanhe o progresso de
+            cada contexto da sua rotina.
+          </p>
+        </div>
+
+        <button type="button" className="primary-action-button">
+          Novo projeto
+        </button>
       </div>
 
-      <section className="module-grid">
-        <article>
-          <strong>0</strong>
-          <span>Projetos ativos</span>
-        </article>
+      {isLoading && (
+        <div className="feedback-card">
+          <strong>Carregando projetos...</strong>
+          <span>Buscando seus projetos cadastrados.</span>
+        </div>
+      )}
 
-        <article>
-          <strong>0</strong>
-          <span>Projetos concluídos</span>
-        </article>
+      {error && (
+        <div className="feedback-card error">
+          <strong>Erro ao carregar projetos</strong>
+          <span>{error}</span>
+        </div>
+      )}
 
-        <article>
-          <strong>0</strong>
-          <span>Projetos arquivados</span>
-        </article>
-      </section>
+      {!isLoading && !error && projects.length === 0 && (
+        <div className="empty-projects-card">
+          <div className="empty-projects-icon">◇</div>
+
+          <h2>Nenhum projeto criado ainda</h2>
+
+          <p>
+            Crie seu primeiro projeto para agrupar tarefas por trabalho,
+            faculdade, rotina pessoal ou qualquer outro contexto.
+          </p>
+
+          <button type="button" className="primary-action-button">
+            Criar primeiro projeto
+          </button>
+        </div>
+      )}
+
+      {!isLoading && !error && projects.length > 0 && (
+        <section className="projects-grid">
+          {projects.map((project) => (
+            <article className="project-card" key={project.id}>
+              <div className="project-card-header">
+                <div>
+                  <span className="project-label">Projeto</span>
+                  <h2>{project.title}</h2>
+                </div>
+
+                <div className="project-actions">
+                  <button type="button" title="Editar projeto">
+                    ✎
+                  </button>
+
+                  <button type="button" title="Excluir projeto">
+                    ×
+                  </button>
+                </div>
+              </div>
+
+              {project.description && (
+                <p className="project-description">{project.description}</p>
+              )}
+
+              {!project.description && (
+                <p className="project-description muted">
+                  Sem descrição cadastrada.
+                </p>
+              )}
+
+              <div className="project-progress-area">
+                <div className="project-progress-header">
+                  <span>Progresso</span>
+                  <strong>{project.progress || 0}%</strong>
+                </div>
+
+                <div className="project-progress-track">
+                  <div
+                    className="project-progress-fill"
+                    style={{ width: `${project.progress || 0}%` }}
+                  ></div>
+                </div>
+
+                <small>
+                  {project.completed_tasks || 0} de {project.total_tasks || 0}{" "}
+                  tarefas concluídas
+                </small>
+              </div>
+
+              <div className="project-card-footer">
+                <div className="project-members">
+                  {project.members?.slice(0, 4).map((member) => (
+                    <div
+                      className="member-avatar"
+                      key={member.id}
+                      title={member.name}
+                    >
+                      {getMemberInitial(member.name)}
+                    </div>
+                  ))}
+
+                  {project.members?.length > 4 && (
+                    <div className="member-avatar extra">
+                      +{project.members.length - 4}
+                    </div>
+                  )}
+
+                  {(!project.members || project.members.length === 0) && (
+                    <div className="member-avatar">U</div>
+                  )}
+                </div>
+
+                <span className="project-members-count">
+                  {project.members?.length || 1} membro
+                  {(project.members?.length || 1) > 1 ? "s" : ""}
+                </span>
+              </div>
+            </article>
+          ))}
+        </section>
+      )}
     </section>
   );
 }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -3,3 +3,13 @@ import axios from "axios";
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
 });
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem("taskflow:token");
+
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+
+  return config;
+});


### PR DESCRIPTION
## O que foi feito

- Atualizado service de API para enviar automaticamente o token JWT nas requisições.
- Criada listagem de projetos consumindo `GET /api/projects`.
- Implementado estado de carregamento da tela de projetos.
- Implementado tratamento de erro ao carregar projetos.
- Implementado estado vazio quando o usuário ainda não possui projetos.
- Criados cards visuais para exibir projetos.
- Cada card exibe título, descrição, barra de progresso, quantidade de tarefas concluídas, membros e botões de editar/excluir.
- Adicionados estilos responsivos para a tela de projetos.