### PR TITLE
feat: add project creation with initial task endpoint

### DIFF
--- a/backend/src/routes/projects.routes.js
+++ b/backend/src/routes/projects.routes.js
@@ -7,6 +7,22 @@ const router = express.Router();
 
 router.use(ensureAuthenticated);
 
+function isDateBeforeToday(date) {
+  const informedDate = new Date(date);
+  const today = new Date();
+
+  informedDate.setHours(0, 0, 0, 0);
+  today.setHours(0, 0, 0, 0);
+
+  return informedDate < today;
+}
+
+function normalizeMemberIds(memberIds, userId) {
+  const safeMemberIds = Array.isArray(memberIds) ? memberIds : [];
+
+  return [...new Set([userId, ...safeMemberIds])];
+}
+
 router.get("/", async (req, res) => {
   try {
     const userId = req.user.id;
@@ -19,39 +35,49 @@ router.get("/", async (req, res) => {
           projects.description,
           projects.created_at,
           projects.updated_at,
-          COUNT(tasks.id)::int AS total_tasks,
-          COUNT(CASE WHEN tasks.status = 'completed' THEN 1 END)::int AS completed_tasks,
+          COALESCE(tasks_summary.total_tasks, 0)::int AS total_tasks,
+          COALESCE(tasks_summary.completed_tasks, 0)::int AS completed_tasks,
           CASE
-            WHEN COUNT(tasks.id) = 0 THEN 0
+            WHEN COALESCE(tasks_summary.total_tasks, 0) = 0 THEN 0
             ELSE ROUND(
-              (COUNT(CASE WHEN tasks.status = 'completed' THEN 1 END)::decimal / COUNT(tasks.id)::decimal) * 100
+              (tasks_summary.completed_tasks::decimal / tasks_summary.total_tasks::decimal) * 100
             )::int
           END AS progress,
-          COALESCE(
+          COALESCE(members_summary.members, '[]') AS members
+        FROM projects
+        LEFT JOIN (
+          SELECT
+            project_id,
+            COUNT(*)::int AS total_tasks,
+            COUNT(CASE WHEN status = 'completed' THEN 1 END)::int AS completed_tasks
+          FROM tasks
+          GROUP BY project_id
+        ) AS tasks_summary
+          ON tasks_summary.project_id = projects.id
+        LEFT JOIN (
+          SELECT
+            project_members.project_id,
             JSON_AGG(
-              DISTINCT JSONB_BUILD_OBJECT(
+              JSONB_BUILD_OBJECT(
                 'id', users.id,
                 'name', users.name,
                 'email', users.email,
                 'role', project_members.role
               )
-            ) FILTER (WHERE users.id IS NOT NULL),
-            '[]'
-          ) AS members
-        FROM projects
-        INNER JOIN project_members
-          ON project_members.project_id = projects.id
-        LEFT JOIN users
-          ON users.id = project_members.user_id
-        LEFT JOIN tasks
-          ON tasks.project_id = projects.id
+              ORDER BY project_members.created_at ASC
+            ) AS members
+          FROM project_members
+          INNER JOIN users
+            ON users.id = project_members.user_id
+          GROUP BY project_members.project_id
+        ) AS members_summary
+          ON members_summary.project_id = projects.id
         WHERE projects.owner_id = $1
           OR projects.id IN (
             SELECT project_id
             FROM project_members
             WHERE user_id = $1
           )
-        GROUP BY projects.id
         ORDER BY projects.created_at DESC
       `,
       [userId]
@@ -66,6 +92,146 @@ router.get("/", async (req, res) => {
     return res.status(500).json({
       message: "Erro interno ao listar projetos.",
     });
+  }
+});
+
+router.post("/with-initial-task", async (req, res) => {
+  const client = await pool.connect();
+
+  try {
+    const userId = req.user.id;
+    const { project, task } = req.body;
+
+    if (!project?.title || !project.title.trim()) {
+      return res.status(400).json({
+        message: "Informe o nome do projeto.",
+      });
+    }
+
+    if (!task?.title || !task.title.trim()) {
+      return res.status(400).json({
+        message: "Informe o título da tarefa inicial.",
+      });
+    }
+
+    if (!task?.dueDate) {
+      return res.status(400).json({
+        message: "Informe a data final da tarefa inicial.",
+      });
+    }
+
+    if (isDateBeforeToday(task.dueDate)) {
+      return res.status(400).json({
+        message: "A data final da tarefa não pode ser anterior à data atual.",
+      });
+    }
+
+    const allowedPriorities = ["low", "medium", "high"];
+    const priority = allowedPriorities.includes(task.priority)
+      ? task.priority
+      : "medium";
+
+    const memberIds = normalizeMemberIds(project.memberIds, userId);
+    const assignedUserId = task.assignedUserId || userId;
+
+    if (!memberIds.includes(assignedUserId)) {
+      return res.status(400).json({
+        message: "O responsável da tarefa deve ser membro do projeto.",
+      });
+    }
+
+    await client.query("BEGIN");
+
+    const membersResult = await client.query(
+      `
+        SELECT id
+        FROM users
+        WHERE id = ANY($1::uuid[])
+      `,
+      [memberIds]
+    );
+
+    if (membersResult.rows.length !== memberIds.length) {
+      await client.query("ROLLBACK");
+
+      return res.status(400).json({
+        message: "Um ou mais membros informados não foram encontrados.",
+      });
+    }
+
+    const projectResult = await client.query(
+      `
+        INSERT INTO projects (owner_id, title, description)
+        VALUES ($1, $2, $3)
+        RETURNING id, owner_id, title, description, created_at, updated_at
+      `,
+      [userId, project.title.trim(), project.description?.trim() || null]
+    );
+
+    const createdProject = projectResult.rows[0];
+
+    for (const memberId of memberIds) {
+      await client.query(
+        `
+          INSERT INTO project_members (project_id, user_id, role)
+          VALUES ($1, $2, $3)
+        `,
+        [createdProject.id, memberId, memberId === userId ? "owner" : "member"]
+      );
+    }
+
+    const taskResult = await client.query(
+      `
+        INSERT INTO tasks (
+          project_id,
+          assigned_user_id,
+          title,
+          description,
+          status,
+          priority,
+          due_date
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        RETURNING
+          id,
+          project_id,
+          assigned_user_id,
+          title,
+          description,
+          status,
+          priority,
+          due_date,
+          created_at,
+          updated_at
+      `,
+      [
+        createdProject.id,
+        assignedUserId,
+        task.title.trim(),
+        task.description?.trim() || null,
+        "pending",
+        priority,
+        task.dueDate,
+      ]
+    );
+
+    await client.query("COMMIT");
+
+    return res.status(201).json({
+      message: "Projeto e tarefa inicial criados com sucesso.",
+      project: createdProject,
+      task: taskResult.rows[0],
+    });
+  } catch (error) {
+    await client.query("ROLLBACK");
+
+    console.error("Create project with initial task error:", error);
+
+    return res.status(500).json({
+      message: "Erro interno ao criar projeto com tarefa inicial.",
+    });
+  } finally {
+    client.release();
   }
 });
 


### PR DESCRIPTION
## O que foi feito

- Criado endpoint `POST /api/projects/with-initial-task`.
- Implementada criação de projeto e tarefa inicial em uma única transação.
- Implementada inclusão automática do usuário logado como membro dono do projeto.
- Implementado vínculo de membros adicionais ao projeto.
- Implementada definição de responsável pela tarefa inicial.
- Definido usuário logado como responsável padrão quando nenhum responsável é informado.
- Implementada validação para impedir data final anterior à data atual.
- Implementada validação para garantir que o responsável da tarefa seja membro do projeto.
- Implementada validação de prioridade da tarefa.
- Mantida transação com rollback em caso de erro.
