### PR TITLE
feat: add members selection to project modal

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1633,3 +1633,106 @@ a:hover {
     grid-template-columns: 1fr;
   }
 }
+
+.member-search-status {
+  margin-top: 10px;
+  color: #667085;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.member-search-results {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.member-search-option {
+  width: 100%;
+  border: 1px solid #d0d7e2;
+  border-radius: 16px;
+  padding: 10px;
+  cursor: pointer;
+  background: #ffffff;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-align: left;
+  transition:
+    border-color 0.2s,
+    background 0.2s,
+    transform 0.2s;
+}
+
+.member-search-option:hover {
+  border-color: #556cff;
+  background: #eef2ff;
+  transform: translateY(-1px);
+}
+
+.member-search-option strong,
+.member-search-option span {
+  display: block;
+}
+
+.member-search-option strong {
+  color: #172033;
+  font-size: 14px;
+}
+
+.member-search-option span {
+  margin-top: 2px;
+  color: #667085;
+  font-size: 12px;
+}
+
+.selected-members-list {
+  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.selected-member-pill {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  border: 1px solid #edf1f7;
+  border-radius: 16px;
+  background: #ffffff;
+}
+
+.selected-member-pill > div:nth-child(2) {
+  min-width: 0;
+  flex: 1;
+}
+
+.selected-member-pill strong,
+.selected-member-pill span {
+  display: block;
+}
+
+.selected-member-pill strong {
+  color: #172033;
+  font-size: 14px;
+}
+
+.selected-member-pill span {
+  margin-top: 2px;
+  color: #667085;
+  font-size: 12px;
+}
+
+.selected-member-pill > button {
+  width: 30px;
+  height: 30px;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  color: #b42318;
+  background: #fff1f0;
+  font-size: 18px;
+  font-weight: 900;
+}

--- a/frontend/src/pages/Projects.jsx
+++ b/frontend/src/pages/Projects.jsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { api } from "../services/api";
 
 export default function Projects() {
+  const currentUser = JSON.parse(localStorage.getItem("taskflow:user") || "null");
+
   const [projects, setProjects] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
@@ -11,6 +13,12 @@ export default function Projects() {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [editingProject, setEditingProject] = useState(null);
   const [projectToDelete, setProjectToDelete] = useState(null);
+
+  const [selectedMembers, setSelectedMembers] = useState([]);
+  const [memberSearch, setMemberSearch] = useState("");
+  const [memberSearchResults, setMemberSearchResults] = useState([]);
+  const [isSearchingMembers, setIsSearchingMembers] = useState(false);
+  const [taskResponsibleId, setTaskResponsibleId] = useState("");
 
   const [editForm, setEditForm] = useState({
     title: "",
@@ -39,18 +47,122 @@ export default function Projects() {
     loadProjects();
   }, []);
 
+  useEffect(() => {
+    if (!isCreateModalOpen || memberSearch.trim().length < 2) {
+      setMemberSearchResults([]);
+      return;
+    }
+
+    let shouldIgnoreResponse = false;
+
+    async function searchMembers() {
+      try {
+        setIsSearchingMembers(true);
+
+        const response = await api.get("/users", {
+          params: {
+            search: memberSearch.trim(),
+          },
+        });
+
+        if (shouldIgnoreResponse) {
+          return;
+        }
+
+        const selectedMemberIds = selectedMembers.map((member) => member.id);
+
+        const availableUsers = response.data.users.filter(
+          (user) => !selectedMemberIds.includes(user.id)
+        );
+
+        setMemberSearchResults(availableUsers);
+      } catch (error) {
+        if (!shouldIgnoreResponse) {
+          setMemberSearchResults([]);
+        }
+      } finally {
+        if (!shouldIgnoreResponse) {
+          setIsSearchingMembers(false);
+        }
+      }
+    }
+
+    const timeoutId = setTimeout(searchMembers, 350);
+
+    return () => {
+      shouldIgnoreResponse = true;
+      clearTimeout(timeoutId);
+    };
+  }, [isCreateModalOpen, memberSearch, selectedMembers]);
+
   function getMemberInitial(memberName) {
     return memberName?.charAt(0)?.toUpperCase() || "U";
   }
 
+  function getDefaultMembers() {
+    if (!currentUser?.id) {
+      return [];
+    }
+
+    return [
+      {
+        id: currentUser.id,
+        name: currentUser.name || "Usuário logado",
+        email: currentUser.email || "",
+        role: "owner",
+      },
+    ];
+  }
+
   function openCreateModal() {
+    const defaultMembers = getDefaultMembers();
+
     setFeedback("");
     setError("");
+    setMemberSearch("");
+    setMemberSearchResults([]);
+    setSelectedMembers(defaultMembers);
+    setTaskResponsibleId(defaultMembers[0]?.id || "");
     setIsCreateModalOpen(true);
   }
 
   function closeCreateModal() {
     setIsCreateModalOpen(false);
+    setMemberSearch("");
+    setMemberSearchResults([]);
+    setSelectedMembers([]);
+    setTaskResponsibleId("");
+  }
+
+  function addMember(member) {
+    setSelectedMembers((currentMembers) => {
+      const memberAlreadySelected = currentMembers.some(
+        (currentMember) => currentMember.id === member.id
+      );
+
+      if (memberAlreadySelected) {
+        return currentMembers;
+      }
+
+      return [...currentMembers, member];
+    });
+
+    setMemberSearch("");
+    setMemberSearchResults([]);
+  }
+
+  function removeMember(memberId) {
+    if (memberId === currentUser?.id) {
+      return;
+    }
+
+    setSelectedMembers((currentMembers) =>
+      currentMembers.filter((member) => member.id !== memberId)
+    );
+
+    if (taskResponsibleId === memberId) {
+      setTaskResponsibleId(currentUser?.id || "");
+    }
   }
 
   function openEditModal(project) {
@@ -324,13 +436,75 @@ export default function Projects() {
                     Membros
                     <input
                       type="text"
-                      placeholder="Digite o nome de um colega"
+                      placeholder="Digite nome ou email de um colega"
+                      value={memberSearch}
+                      onChange={(event) => setMemberSearch(event.target.value)}
                     />
                   </label>
 
-                  <div className="selected-members-preview">
-                    <div className="member-avatar">U</div>
-                    <span>Usuário logado será adicionado por padrão</span>
+                  {isSearchingMembers && (
+                    <div className="member-search-status">
+                      Buscando usuários...
+                    </div>
+                  )}
+
+                  {memberSearchResults.length > 0 && (
+                    <div className="member-search-results">
+                      {memberSearchResults.map((member) => (
+                        <button
+                          type="button"
+                          className="member-search-option"
+                          key={member.id}
+                          onClick={() => addMember(member)}
+                        >
+                          <div className="member-avatar">
+                            {getMemberInitial(member.name)}
+                          </div>
+
+                          <div>
+                            <strong>{member.name}</strong>
+                            <span>{member.email}</span>
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+
+                  {memberSearch.trim().length >= 2 &&
+                    !isSearchingMembers &&
+                    memberSearchResults.length === 0 && (
+                      <div className="member-search-status">
+                        Nenhum usuário encontrado.
+                      </div>
+                    )}
+
+                  <div className="selected-members-list">
+                    {selectedMembers.map((member) => (
+                      <div className="selected-member-pill" key={member.id}>
+                        <div className="member-avatar">
+                          {getMemberInitial(member.name)}
+                        </div>
+
+                        <div>
+                          <strong>{member.name}</strong>
+                          <span>
+                            {member.id === currentUser?.id
+                              ? "Você"
+                              : member.email}
+                          </span>
+                        </div>
+
+                        {member.id !== currentUser?.id && (
+                          <button
+                            type="button"
+                            onClick={() => removeMember(member.id)}
+                            title="Remover membro"
+                          >
+                            ×
+                          </button>
+                        )}
+                      </div>
+                    ))}
                   </div>
                 </section>
 
@@ -358,8 +532,17 @@ export default function Projects() {
 
                     <label>
                       Responsável
-                      <select defaultValue="usuario-logado">
-                        <option value="usuario-logado">Usuário logado</option>
+                      <select
+                        value={taskResponsibleId}
+                        onChange={(event) =>
+                          setTaskResponsibleId(event.target.value)
+                        }
+                      >
+                        {selectedMembers.map((member) => (
+                          <option key={member.id} value={member.id}>
+                            {member.name}
+                          </option>
+                        ))}
                       </select>
                     </label>
                   </div>


### PR DESCRIPTION
## O que foi feito

- Implementada busca de usuários no campo Membros da modal de novo projeto.
- Integrado o campo Membros com o endpoint `GET /api/users`.
- Adicionada seleção de usuários como membros do projeto.
- Exibidos avatares dos membros selecionados imediatamente após a seleção.
- Adicionada opção para remover membros selecionados.
- Mantido o usuário logado como membro padrão do projeto.
- Disponibilizados os membros selecionados no dropdown de Responsável da tarefa inicial.
- Mantido o usuário logado como responsável padrão.