### PR TITLE
test: add coverage report configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,12 @@ pnpm-debug.log*
 # Build
 dist/
 build/
+frontend/dist/
+
+# Coverage
+coverage/
+backend/coverage/
+frontend/coverage/
 
 # Java / class files
 *.class

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
     "migrate": "node src/database/migrate.js",
-    "test": "jest"
+    "test": "jest",
+    "test:coverage": "jest --coverage"
   },
   "keywords": [],
   "author": "",
@@ -23,5 +24,19 @@
   "devDependencies": {
     "jest": "^30.3.0",
     "nodemon": "^3.1.14"
+  },
+  "jest": {
+    "collectCoverage": true,
+    "coverageDirectory": "coverage",
+    "coverageReporters": [
+      "text",
+      "lcov"
+    ],
+    "collectCoverageFrom": [
+      "src/**/*.js",
+      "!src/database/connection.js",
+      "!src/database/migrate.js",
+      "!src/server.js"
+    ]
   }
 }

--- a/backend/src/utils/validators.js
+++ b/backend/src/utils/validators.js
@@ -1,15 +1,25 @@
 function isValidEmail(email) {
-    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+  if (!email) {
+    return false;
   }
-  
-  function isValidPassword(password) {
-    const hasMinimumLength = password.length >= 4;
-    const hasUppercaseLetter = /[A-Z]/.test(password);
-  
-    return hasMinimumLength && hasUppercaseLetter;
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  return emailRegex.test(email);
+}
+
+function isValidPassword(password) {
+  if (!password) {
+    return false;
   }
-  
-  module.exports = {
-    isValidEmail,
-    isValidPassword,
-  };
+
+  const hasMinimumLength = password.length >= 4;
+  const hasUppercaseLetter = /[A-Z]/.test(password);
+
+  return hasMinimumLength && hasUppercaseLetter;
+}
+
+module.exports = {
+  isValidEmail,
+  isValidPassword,
+};

--- a/backend/tests/validators.test.js
+++ b/backend/tests/validators.test.js
@@ -6,6 +6,10 @@ describe("Auth validators", () => {
       expect(isValidEmail("usuario@email.com")).toBe(true);
     });
 
+    test("should return true for a valid email with subdomain", () => {
+      expect(isValidEmail("usuario@aluno.ufla.br")).toBe(true);
+    });
+
     test("should return false for email without domain separator", () => {
       expect(isValidEmail("usuarioemail.com")).toBe(false);
     });
@@ -21,11 +25,23 @@ describe("Auth validators", () => {
     test("should return false for empty email", () => {
       expect(isValidEmail("")).toBe(false);
     });
+
+    test("should return false for null email", () => {
+      expect(isValidEmail(null)).toBe(false);
+    });
+
+    test("should return false for undefined email", () => {
+      expect(isValidEmail(undefined)).toBe(false);
+    });
   });
 
   describe("isValidPassword", () => {
     test("should return true for password with minimum length and uppercase letter", () => {
       expect(isValidPassword("Teste")).toBe(true);
+    });
+
+    test("should return true for password with more than 4 characters and uppercase letter", () => {
+      expect(isValidPassword("SenhaForte")).toBe(true);
     });
 
     test("should return false for password with less than 4 characters", () => {
@@ -38,6 +54,14 @@ describe("Auth validators", () => {
 
     test("should return false for empty password", () => {
       expect(isValidPassword("")).toBe(false);
+    });
+
+    test("should return false for null password", () => {
+      expect(isValidPassword(null)).toBe(false);
+    });
+
+    test("should return false for undefined password", () => {
+      expect(isValidPassword(undefined)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## O que foi feito

- Adicionado script `test:coverage` no backend.
- Configurado Jest para gerar relatórios de cobertura.
- Configurado relatório `lcov`, que será usado posteriormente pelo SonarCloud.
- Ampliados os testes unitários dos validadores de autenticação.
- Adicionados testes para email válido com subdomínio.
- Adicionados testes para valores nulos e indefinidos.
- Garantido que a pasta de cobertura não seja versionada.
