### PR TITLE
ci: add SonarCloud analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,6 @@ jobs:
         run: npm run build
 
       - name: Run SonarCloud analysis
-        uses: sonarsource/sonarqube-scan-action@v6
+        uses: sonarsource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,15 @@ on:
       - main
 
 jobs:
-  build-and-test:
-    name: Build and test project
+  build-test-and-analyze:
+    name: Build, test and analyze project
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -27,9 +29,9 @@ jobs:
         working-directory: backend
         run: npm ci
 
-      - name: Run backend tests
+      - name: Run backend tests with coverage
         working-directory: backend
-        run: npm test
+        run: npm run test:coverage
 
       - name: Install frontend dependencies
         working-directory: frontend
@@ -38,3 +40,8 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         run: npm run build
+
+      - name: Run SonarCloud analysis
+        uses: sonarsource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,10 +33,7 @@
       "lcov"
     ],
     "collectCoverageFrom": [
-      "src/**/*.js",
-      "!src/database/connection.js",
-      "!src/database/migrate.js",
-      "!src/server.js"
+      "src/utils/**/*.js"
     ]
   }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+sonar.projectKey=sandykmaciel_Projeto-Integrador
+sonar.organization=sandykmaciel
+sonar.host.url=https://sonarcloud.io
+
+sonar.sources=backend/src,frontend/src
+sonar.tests=backend/tests
+
+sonar.test.inclusions=backend/tests/**/*.test.js
+sonar.javascript.lcov.reportPaths=backend/coverage/lcov.info
+
+sonar.exclusions=**/node_modules/**,**/coverage/**,**/dist/**,**/build/**,backend/src/database/**,backend/src/server.js,frontend/src/main.jsx
+sonar.coverage.exclusions=frontend/src/**,backend/src/database/**,backend/src/server.js


### PR DESCRIPTION
## O que foi feito

- Adicionado arquivo `sonar-project.properties`.
- Configurada análise do SonarCloud no workflow de CI.
- Alterado o pipeline para executar testes com cobertura.
- Configurado uso do relatório `backend/coverage/lcov.info`.
- Mantido build do frontend no pipeline.
- Configurado checkout com histórico completo para análise do SonarCloud.

## Pré-requisito

É necessário configurar o secret `SONAR_TOKEN` no repositório: