### PR TITLE
docs: add sprint retrospectives

### DIFF
--- a/docs/retrospectivas/sprint1.md
+++ b/docs/retrospectivas/sprint1.md
@@ -1,0 +1,23 @@
+# Retrospectiva - Sprint 1
+
+## Resumo da sprint
+
+Na Sprint 1, o foco foi construir a base inicial do TaskFlow, incluindo cadastro de usuários, login com autenticação, recuperação de senha, estrutura de navegação autenticada com sidebar e navbar, além da configuração inicial de testes unitários no backend.
+
+## Start
+
+- Padronizar melhor a descrição dos Pull Requests desde o início da sprint, incluindo objetivo, arquivos alterados e forma de teste.
+- Criar testes unitários junto com as funcionalidades, evitando deixar os testes apenas para o final da sprint.
+- Registrar decisões técnicas importantes no README ou em documentos auxiliares para facilitar a continuidade do projeto.
+
+## Stop
+
+- Evitar realizar alterações diretamente na branch `main`, mantendo todo desenvolvimento por branches e Pull Requests.
+- Evitar acumular muitas mudanças em um único commit, pois isso dificulta a revisão pelos colegas.
+- Evitar deixar validações importantes somente no frontend, garantindo também validações no backend.
+
+## Continue
+
+- Continuar utilizando GitHub Projects para acompanhar o andamento das atividades da sprint.
+- Continuar utilizando Pull Requests com descrição e revisão obrigatória por colega.
+- Continuar separando as funcionalidades em commits menores e com mensagens padronizadas.

--- a/docs/retrospectivas/sprint2.md
+++ b/docs/retrospectivas/sprint2.md
@@ -1,0 +1,23 @@
+# Retrospectiva - Sprint 2
+
+## Resumo da sprint
+
+Na Sprint 2, o foco foi evoluir o módulo de projetos, permitindo visualização em cards, edição, exclusão com confirmação, criação de projeto com tarefa inicial, seleção de membros e listagem inicial de tarefas. Também foram trabalhados requisitos técnicos de qualidade, como pipeline de CI, SonarCloud, cobertura de testes, Docker e documentação de retrospectivas.
+
+## Start
+
+- Iniciar a sprint validando os critérios técnicos obrigatórios, como pipeline, Docker, SonarCloud e cobertura de testes.
+- Criar documentação técnica incremental para cada card entregue, reduzindo retrabalho no fechamento da sprint.
+- Planejar melhor a divisão entre funcionalidades de backend, frontend e infraestrutura antes de iniciar os commits.
+
+## Stop
+
+- Evitar deixar requisitos de qualidade e infraestrutura para o final da sprint.
+- Evitar implementar fluxos grandes em um único Pull Request, principalmente quando envolvem backend, frontend e banco de dados.
+- Evitar seguir para novos cards sem validar localmente build, testes, Docker e integração com a API.
+
+## Continue
+
+- Continuar mantendo a branch `main` protegida com Pull Requests e aprovação de colegas.
+- Continuar utilizando commits semânticos, como `feat`, `fix`, `docs`, `test`, `ci` e `chore`.
+- Continuar validando as funcionalidades manualmente no navegador e também por endpoints quando necessário.


### PR DESCRIPTION
## O que foi feito

- Criada a pasta `docs/retrospectivas`.
- Adicionado arquivo de retrospectiva da Sprint 1.
- Adicionado arquivo de retrospectiva da Sprint 2.
- As retrospectivas seguem o formato Start / Stop / Continue.
- Cada categoria possui pelo menos 3 itens.

## Como testar

1. Acessar a pasta `docs/retrospectivas`.
2. Validar se existem os arquivos:
   - `sprint1.md`
   - `sprint2.md`
3. Conferir se ambos seguem o formato:
   - Start
   - Stop
   - Continue
4. Validar se cada categoria possui no mínimo 3 itens.

## Observações

Este PR adiciona a documentação de retrospectiva exigida para as Sprints 1 e 2.