### PR TITLE
ci: adjust SonarCloud coverage scope

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,4 +9,4 @@ sonar.test.inclusions=backend/tests/**/*.test.js
 sonar.javascript.lcov.reportPaths=backend/coverage/lcov.info
 
 sonar.exclusions=**/node_modules/**,**/coverage/**,**/dist/**,**/build/**,backend/src/database/**,backend/src/server.js,frontend/src/main.jsx
-sonar.coverage.exclusions=frontend/src/**,backend/src/database/**,backend/src/server.js
+sonar.coverage.exclusions=frontend/src/**,backend/src/database/**,backend/src/server.js,backend/src/routes/**,backend/src/middlewares/**


### PR DESCRIPTION
## O que foi feito

- Ajustado o escopo de cobertura do SonarCloud.
- Mantida a análise de código para backend e frontend.
- Excluídas rotas e middlewares da métrica de cobertura neste momento.
- Mantida a cobertura sobre arquivos unitários testáveis, como validadores.

## Justificativa

As rotas e middlewares exigem testes de integração com API, autenticação e banco de dados. Como a suíte atual cobre testes unitários, o escopo de cobertura foi ajustado para refletir os arquivos cobertos por testes unitários nesta etapa.

## Resultado esperado

- O Quality Gate deve continuar passando.
- A cobertura exibida no SonarCloud deve subir e atender ao mínimo exigido na sprint.