### PR TITLE
feat: create project details page route

### DIFF
--- a/backend/src/database/migrate.js
+++ b/backend/src/database/migrate.js
@@ -88,8 +88,34 @@ async function migrate() {
         priority VARCHAR(40) NOT NULL DEFAULT 'medium',
         due_date TIMESTAMP NULL,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-        pdated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
   );
+`);
+
+    await pool.query(`
+  DO $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_name = 'tasks'
+        AND column_name = 'pdated_at'
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_name = 'tasks'
+        AND column_name = 'updated_at'
+    )
+    THEN
+      ALTER TABLE tasks RENAME COLUMN pdated_at TO updated_at;
+    END IF;
+  END $$;
+`);
+
+    await pool.query(`
+      ALTER TABLE tasks
+      ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
 `);
 
     await pool.query(`

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import ProfileSettings from "./pages/ProfileSettings";
 import Notifications from "./pages/Notifications";
 import History from "./pages/History";
 import AuthenticatedLayout from "./layouts/AuthenticatedLayout";
+import ProjectDetails from "./pages/ProjectDetails";
 
 export default function App() {
   return (
@@ -27,6 +28,7 @@ export default function App() {
           <Route path="/dashboard" element={<Dashboard />} />
 
           <Route path="/projetos" element={<Projects />} />
+          <Route path="/projetos/:id" element={<ProjectDetails />} />
           <Route path="/projects" element={<Navigate to="/projetos" replace />} />
 
           <Route path="/tasks" element={<Tasks />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -43,7 +43,9 @@ export default function Sidebar() {
             key={item.path}
             to={item.path}
             className={({ isActive }) =>
-              isActive ? "sidebar-link active" : "sidebar-link"
+              isActive || window.location.pathname.startsWith(`${item.path}/`)
+                ? "sidebar-link active"
+                : "sidebar-link"
             }
           >
             <span className="sidebar-icon">{item.icon}</span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1991,3 +1991,8 @@ a:hover {
 .modal-feedback {
   margin: 0 0 18px;
 }
+
+.clickable-project-card:focus {
+  outline: 3px solid rgba(85, 108, 255, 0.35);
+  outline-offset: 4px;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1797,3 +1797,197 @@ a:hover {
   color: #4763ff;
   background: #eef2ff;
 }
+
+.clickable-project-card {
+  cursor: pointer;
+}
+
+.project-details-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 34px;
+  border: 1px solid rgba(211, 220, 237, 0.9);
+  border-radius: 30px;
+  background:
+    radial-gradient(circle at top right, rgba(85, 108, 255, 0.14), transparent 30%),
+    rgba(255, 255, 255, 0.96);
+  box-shadow: 0 24px 80px rgba(32, 48, 80, 0.1);
+}
+
+.project-back-link {
+  display: inline-flex;
+  margin-bottom: 18px;
+  color: #4763ff;
+  font-weight: 900;
+  text-decoration: none;
+}
+
+.project-details-header h1 {
+  margin: 8px 0 0;
+  color: #172033;
+  font-size: clamp(34px, 5vw, 58px);
+  letter-spacing: -0.06em;
+  line-height: 0.95;
+}
+
+.project-details-header p {
+  max-width: 720px;
+  margin: 18px 0 0;
+  color: #667085;
+  font-size: 17px;
+  line-height: 1.6;
+}
+
+.project-details-actions {
+  display: flex;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+.project-details-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.project-summary-card {
+  padding: 24px;
+  border: 1px solid rgba(211, 220, 237, 0.9);
+  border-radius: 26px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 20px 60px rgba(32, 48, 80, 0.08);
+}
+
+.project-summary-card span,
+.project-summary-card small {
+  display: block;
+  color: #667085;
+  font-weight: 800;
+}
+
+.project-summary-card strong {
+  display: block;
+  margin: 12px 0 8px;
+  color: #172033;
+  font-size: 40px;
+  letter-spacing: -0.05em;
+}
+
+.project-details-panel {
+  padding: 28px;
+  border: 1px solid rgba(211, 220, 237, 0.9);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 20px 60px rgba(32, 48, 80, 0.08);
+}
+
+.project-details-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 20px;
+}
+
+.project-details-panel-header h2 {
+  margin: 0;
+  color: #172033;
+  font-size: 26px;
+  letter-spacing: -0.04em;
+}
+
+.project-details-panel-header p {
+  margin: 8px 0 0;
+  color: #667085;
+  line-height: 1.5;
+}
+
+.project-details-panel-header > strong {
+  color: #4763ff;
+  font-size: 28px;
+}
+
+.details-progress-track {
+  height: 16px;
+}
+
+.project-details-members-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.project-details-member {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid #edf1f7;
+  border-radius: 18px;
+  background: #f8fbff;
+}
+
+.project-details-member > div:nth-child(2) {
+  min-width: 0;
+  flex: 1;
+}
+
+.project-details-member strong,
+.project-details-member span {
+  display: block;
+}
+
+.project-details-member strong {
+  color: #172033;
+  font-size: 14px;
+}
+
+.project-details-member span {
+  margin-top: 3px;
+  color: #667085;
+  font-size: 12px;
+}
+
+.project-details-member small {
+  color: #4763ff;
+  font-weight: 900;
+}
+
+.project-details-back-button {
+  margin-top: 16px;
+}
+
+@media (max-width: 1100px) {
+  .project-details-header {
+    flex-direction: column;
+  }
+
+  .project-details-actions {
+    width: 100%;
+  }
+
+  .project-details-actions button {
+    flex: 1;
+  }
+
+  .project-details-members-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .project-details-summary-grid,
+  .project-details-members-list {
+    grid-template-columns: 1fr;
+  }
+
+  .project-details-panel-header {
+    flex-direction: column;
+  }
+}
+
+.modal-feedback {
+  margin: 0 0 18px;
+}

--- a/frontend/src/pages/ProjectDetails.jsx
+++ b/frontend/src/pages/ProjectDetails.jsx
@@ -1,0 +1,202 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { api } from "../services/api";
+
+export default function ProjectDetails() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  const [project, setProject] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  async function loadProjectDetails() {
+    try {
+      setIsLoading(true);
+      setError("");
+
+      const response = await api.get(`/projects/${id}`);
+
+      setProject(response.data.project);
+    } catch (error) {
+      const message =
+        error.response?.data?.message ||
+        "Não foi possível carregar os detalhes do projeto.";
+
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadProjectDetails();
+  }, [id]);
+
+  function getMemberInitial(memberName) {
+    return memberName?.charAt(0)?.toUpperCase() || "U";
+  }
+
+  if (isLoading) {
+    return (
+      <section className="module-screen">
+        <div className="feedback-card">
+          <strong>Carregando projeto...</strong>
+          <span>Buscando os dados consolidados desta iniciativa.</span>
+        </div>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="module-screen">
+        <div className="feedback-card error">
+          <strong>Erro ao carregar projeto</strong>
+          <span>{error}</span>
+        </div>
+
+        <button
+          type="button"
+          className="secondary-action-button project-details-back-button"
+          onClick={() => navigate("/projetos")}
+        >
+          Voltar para projetos
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section className="module-screen">
+      <div className="project-details-header">
+        <div>
+          <Link to="/projetos" className="project-back-link">
+            ← Voltar para projetos
+          </Link>
+
+          <span className="eyebrow">Detalhes do projeto</span>
+
+          <h1>{project.title}</h1>
+
+          <p>
+            {project.description ||
+              "Projeto sem descrição cadastrada até o momento."}
+          </p>
+        </div>
+
+        <div className="project-details-actions">
+          <button type="button" className="secondary-action-button">
+            Editar projeto
+          </button>
+
+          <button type="button" className="danger-action-button">
+            Excluir projeto
+          </button>
+        </div>
+      </div>
+
+      <section className="project-details-summary-grid">
+        <article className="project-summary-card">
+          <span>Total de tarefas</span>
+          <strong>{project.total_tasks || 0}</strong>
+          <small>Tarefas vinculadas a este projeto</small>
+        </article>
+
+        <article className="project-summary-card">
+          <span>Concluídas</span>
+          <strong>{project.completed_tasks || 0}</strong>
+          <small>Tarefas marcadas como concluídas</small>
+        </article>
+
+        <article className="project-summary-card">
+          <span>Progresso</span>
+          <strong>{project.progress || 0}%</strong>
+          <small>Atualizado conforme conclusão das tarefas</small>
+        </article>
+      </section>
+
+      <section className="project-details-panel">
+        <div className="project-details-panel-header">
+          <div>
+            <h2>Progresso do projeto</h2>
+            <p>Acompanhe o andamento geral das atividades vinculadas.</p>
+          </div>
+
+          <strong>{project.progress || 0}%</strong>
+        </div>
+
+        <div className="project-progress-track details-progress-track">
+          <div
+            className="project-progress-fill"
+            style={{ width: `${project.progress || 0}%` }}
+          ></div>
+        </div>
+      </section>
+
+      <section className="project-details-panel">
+        <div className="project-details-panel-header">
+          <div>
+            <h2>Membros do projeto</h2>
+            <p>Integrantes vinculados a esta iniciativa.</p>
+          </div>
+        </div>
+
+        <div className="project-details-members-list">
+          {project.members?.map((member) => (
+            <div className="project-details-member" key={member.id}>
+              <div className="member-avatar">
+                {getMemberInitial(member.name)}
+              </div>
+
+              <div>
+                <strong>{member.name}</strong>
+                <span>{member.email}</span>
+              </div>
+
+              <small>{member.role === "owner" ? "Dono" : "Membro"}</small>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="project-details-panel">
+        <div className="project-details-panel-header">
+          <div>
+            <h2>Tarefas do projeto</h2>
+            <p>
+              A tabela detalhada de tarefas será exibida aqui no próximo passo.
+            </p>
+          </div>
+
+          <button type="button" className="primary-action-button">
+            + Nova tarefa
+          </button>
+        </div>
+
+        <div className="tasks-table-wrapper">
+          <table className="tasks-table">
+            <thead>
+              <tr>
+                <th>Tarefas</th>
+                <th>Descrição</th>
+                <th>Prioridade</th>
+                <th>Responsável</th>
+                <th>Data Final</th>
+                <th>Ações</th>
+              </tr>
+            </thead>
+
+            <tbody>
+              <tr>
+                <td colSpan="6" className="empty-table-cell">
+                  A listagem de tarefas será implementada no próximo commit.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/frontend/src/pages/Projects.jsx
+++ b/frontend/src/pages/Projects.jsx
@@ -492,7 +492,15 @@ export default function Projects() {
             <article
               className="project-card clickable-project-card"
               key={project.id}
+              role="button"
+              tabIndex={0}
               onClick={() => navigate(`/projetos/${project.id}`)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  navigate(`/projetos/${project.id}`);
+                }
+              }}
             >
               <div className="project-card-header">
                 <div>

--- a/frontend/src/pages/Projects.jsx
+++ b/frontend/src/pages/Projects.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { api } from "../services/api";
 
 const priorityLabels = {
@@ -9,6 +10,7 @@ const priorityLabels = {
 
 export default function Projects() {
   const currentUser = JSON.parse(localStorage.getItem("taskflow:user") || "null");
+  const navigate = useNavigate();
 
   const [projects, setProjects] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -24,6 +26,7 @@ export default function Projects() {
   const [memberSearch, setMemberSearch] = useState("");
   const [memberSearchResults, setMemberSearchResults] = useState([]);
   const [isSearchingMembers, setIsSearchingMembers] = useState(false);
+  const [createModalError, setCreateModalError] = useState("");
 
   const [createForm, setCreateForm] = useState({
     projectTitle: "",
@@ -191,6 +194,7 @@ export default function Projects() {
 
     setFeedback("");
     setError("");
+    setCreateModalError("");
     setMemberSearch("");
     setMemberSearchResults([]);
     setSelectedMembers(defaultMembers);
@@ -206,13 +210,13 @@ export default function Projects() {
     });
     setIsCreateModalOpen(true);
   }
-
   function closeCreateModal() {
     setIsCreateModalOpen(false);
     setMemberSearch("");
     setMemberSearchResults([]);
     setSelectedMembers([]);
     resetCreateForm();
+    setCreateModalError("");
   }
 
   function handleCreateFormChange(event) {
@@ -286,7 +290,7 @@ export default function Projects() {
     const validationError = validateCreateForm();
 
     if (validationError) {
-      setError(validationError);
+      setCreateModalError(validationError);
       return;
     }
 
@@ -322,7 +326,7 @@ export default function Projects() {
         error.response?.data?.message ||
         "Não foi possível criar o projeto com tarefa inicial.";
 
-      setError(message);
+      setCreateModalError(message);
     } finally {
       setIsSaving(false);
     }
@@ -365,7 +369,7 @@ export default function Projects() {
 
     try {
       setIsSaving(true);
-      setError("");
+      setCreateModalError("");
       setFeedback("");
 
       await api.put(`/projects/${editingProject.id}`, {
@@ -485,7 +489,11 @@ export default function Projects() {
       {!isLoading && projects.length > 0 && (
         <section className="projects-grid">
           {projects.map((project) => (
-            <article className="project-card" key={project.id}>
+            <article
+              className="project-card clickable-project-card"
+              key={project.id}
+              onClick={() => navigate(`/projetos/${project.id}`)}
+            >
               <div className="project-card-header">
                 <div>
                   <span className="project-label">Projeto</span>
@@ -496,7 +504,10 @@ export default function Projects() {
                   <button
                     type="button"
                     title="Editar projeto"
-                    onClick={() => openEditModal(project)}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      openEditModal(project);
+                    }}
                   >
                     ✎
                   </button>
@@ -504,7 +515,10 @@ export default function Projects() {
                   <button
                     type="button"
                     title="Excluir projeto"
-                    onClick={() => openDeleteModal(project)}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      openDeleteModal(project);
+                    }}
                   >
                     ×
                   </button>
@@ -584,6 +598,13 @@ export default function Projects() {
                 ×
               </button>
             </div>
+
+            {createModalError && (
+              <div className="feedback-card error modal-feedback">
+                <strong>Erro</strong>
+                <span>{createModalError}</span>
+              </div>
+            )}
 
             <div className="project-creation-layout">
               <div className="project-creation-column">
@@ -784,14 +805,13 @@ export default function Projects() {
                         <th>Status</th>
                         <th>Data Final</th>
                         <th>Prioridade</th>
-                        <th>Ações</th>
                       </tr>
                     </thead>
 
                     <tbody>
                       {filteredInitialTasks.length === 0 && (
                         <tr>
-                          <td colSpan="5" className="empty-table-cell">
+                          <td colSpan="4" className="empty-table-cell">
                             Nenhuma tarefa encontrada.
                           </td>
                         </tr>
@@ -817,16 +837,6 @@ export default function Projects() {
                             >
                               {priorityLabels[task.priority]}
                             </span>
-                          </td>
-                          <td>
-                            <div className="task-table-actions">
-                              <button type="button" title="Editar tarefa">
-                                ✎
-                              </button>
-                              <button type="button" title="Excluir tarefa">
-                                ×
-                              </button>
-                            </div>
                           </td>
                         </tr>
                       ))}


### PR DESCRIPTION
## O que foi feito

- Criada página interna de detalhes do projeto.
- Adicionada rota `/projetos/:id`.
- Implementado carregamento de dados do projeto via `GET /api/projects/:id`.
- Adicionado clique nos cards de projeto para abrir a página interna.
- Mantidos botões de editar/excluir no card sem disparar navegação.
- Exibido nome do projeto em destaque.
- Exibida descrição do projeto.
- Exibidos indicadores de total de tarefas, tarefas concluídas e progresso.
- Exibida barra de progresso do projeto.
- Exibida lista de membros vinculados ao projeto.
- Adicionada estrutura inicial da tabela de tarefas.
- Mantido módulo Projetos ativo na sidebar para rotas internas.

## Como testar

1. Rodar backend e frontend.
2. Fazer login.
3. Acessar `/projetos`.
4. Clicar em um card de projeto.
5. Validar se a rota `/projetos/:id` é carregada.
6. Validar se o nome, descrição, progresso e membros aparecem.
7. Validar se a tabela base de tarefas aparece.
8. Validar se a sidebar continua destacando Projetos.
9. Clicar em voltar para projetos.

## Resultado esperado

- O usuário deve conseguir acessar a página interna ao clicar em um projeto.
- A página deve exibir os dados consolidados do projeto selecionado.
- A rota deve manter a navegação autenticada com sidebar e navbar.
- O módulo Projetos deve permanecer ativo na sidebar.

## Card relacionado

User Story: Página interna de detalhes do projeto